### PR TITLE
Added NSLog alternative (`nsap`) for crash/time benefits.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ AwesomePrint also becomes available in RubyMotion console:
     => nil
     (main)> ap [1,2,3]
 
+There are some ocassions where the framework's `NSLog` has qualities that traditional ruby `puts` does not.  `NSLog` timestamps output and can be found in crash logs.  For these situations you can use `nsap` in place of `ap`.
+
 Supported options and color codes are documented at http://github.com/michaeldv/awesome_print. 
 
 ### Differences with Ruby awesome_print v1.1.0 ###

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ AwesomePrint also becomes available in RubyMotion console:
     => nil
     (main)> ap [1,2,3]
 
-There are some ocassions where the framework's `NSLog` has qualities that traditional ruby `puts` does not.  `NSLog` timestamps output and can be found in crash logs.  For these situations you can use `nsap` in place of `ap`.
+There are some occasions where the framework's `NSLog` has qualities that traditional ruby `puts` does not.  `NSLog` timestamps output and can be found in crash logs.  For these situations you can use `nsap` in place of `ap`.
 
 Supported options and color codes are documented at http://github.com/michaeldv/awesome_print. 
 

--- a/lib/awesome_print_motion/core_ext/kernel.rb
+++ b/lib/awesome_print_motion/core_ext/kernel.rb
@@ -16,6 +16,12 @@ module Kernel
     object unless AwesomePrint.console?
   end
   alias :awesome_print :ap
+  
+  def nsap(object, options = {})
+    NSLog object.ai(options)
+    object unless AwesomePrint.console?
+  end
+  alias :ns_awesome_print :nsap
 
   module_function :ap
 end


### PR DESCRIPTION
There are some occasions where the framework's `NSLog` has qualities that traditional ruby `puts` does not.  `NSLog` timestamps output _AND_ can be found in crash logs.  For these situations you can use `nsap` in place of `ap`.
