### PR TITLE
Support conditional output if BubbleWrap is installed

### DIFF
--- a/lib/awesome_print_motion/core_ext/kernel.rb
+++ b/lib/awesome_print_motion/core_ext/kernel.rb
@@ -12,7 +12,11 @@ module Kernel
   alias :awesome_inspect :ai
 
   def ap(object, options = {})
-    puts object.ai(options)
+    if defined?(BubbleWrap)
+      puts object.ai(options) if BubbleWrap.debug? == true
+    else
+      puts object.ai(options)
+    end
     object unless AwesomePrint.console?
   end
   alias :awesome_print :ap

--- a/test/Rakefile
+++ b/test/Rakefile
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 $:.unshift("/Library/RubyMotion/lib")
-require "motion/project"
+require "motion/project/template/ios"
 require "quickie_motion"
 require File.expand_path(File.dirname(__FILE__) + "/../lib/awesome_print_motion")
 


### PR DESCRIPTION
This is a backwards compatible and non-breaking change that does the following:
1. Detects if the user is using the `BubbleWrap` gem.
2. If not, it does the same thing it has always done.
3. If so, it checks to see if `BW.debug` is set to true.
4. If not, the the `ap` call will not output anything.
5. If so, it will allow the console output to proceed as normal.

This is based on my blog post: http://blog.markrickert.me/leaving-debug-code-in-production-apps and I figured that making it automatic would be useful.

I hope you merge this and release a new gem version! I know a few people that have been pestering me to implement this functionality in this gem.

cc/ @GantMan
