### PR TITLE
Support BigDecimal in RM 2.29

### DIFF
--- a/lib/awesome_print_motion/formatter.rb
+++ b/lib/awesome_print_motion/formatter.rb
@@ -194,7 +194,7 @@ module AwesomePrint
     # Format BigDecimal object.
     #------------------------------------------------------------------------------
     def awesome_bigdecimal(n)
-      colorize(n.to_s("F"), :bigdecimal)
+      colorize(n.stringValue, :bigdecimal)
     end
 
     # Format Rational object.


### PR DESCRIPTION
There is no `Bigdecimal.to_s`, you have to call `stringValue`.
