### PR TITLE
Add working url and mirror to comments

### DIFF
--- a/lib/awesome_print_motion/formatter.rb
+++ b/lib/awesome_print_motion/formatter.rb
@@ -257,7 +257,8 @@ module AwesomePrint
     #------------------------------------------------------------------------------
     def method_tuple(method)
       if method.respond_to?(:parameters) # Ruby 1.9.2+
-        # See http://ruby.runpaint.org/methods#method-objects-parameters
+        # See http://readruby.chengguangnan.com/methods#method-objects-parameters
+        # (mirror: http://archive.is/XguCA#selection-3381.1-3381.11)
         args = method.parameters.inject([]) do |arr, (type, name)|
           name ||= (type == :block ? 'block' : "arg#{arr.size + 1}")
           arr << case type


### PR DESCRIPTION
The old URL points to a random list of scam sites. I also created a mirror in case this url ever goes down, so that finding the expected content won't be as tricky the next time.